### PR TITLE
Fix typo

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ app.use(bodyParser.urlencoded({ extended: true }));
 router(app);
 
 // Server setup
-const port = process.env.PORT || 3090;
+const port = process.env.PORT || 3000;
 const server = http.createServer(app);
 server.listen(port);
 console.log('Server listening on:', port);

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ app.use(bodyParser.urlencoded({ extended: true }));
 router(app);
 
 // Server setup
-const port = process.env.PORT || 3000;
+const port = process.env.PORT || 3090;
 const server = http.createServer(app);
 server.listen(port);
 console.log('Server listening on:', port);

--- a/server/static/index.html
+++ b/server/static/index.html
@@ -1,4 +1,4 @@
-<form action="" method="post">
+<form action="http://localhost:3090/confirmEmail" method="post">
 	<fieldset>
 		<legend>Enter Your Information</legend>
 		

--- a/server/static/index.html
+++ b/server/static/index.html
@@ -1,4 +1,4 @@
-<form action="http://localhost:3090/confirmEmail" method="post">
+<form action="https://gulfex.herokuapp.com/confirmEmail" method="post">
 	<fieldset>
 		<legend>Enter Your Information</legend>
 		

--- a/server/static/index.html
+++ b/server/static/index.html
@@ -1,4 +1,4 @@
-<form action="https://gulfex.herokuapp.com/confirmEmail" method="post">
+<form action="" method="post">
 	<fieldset>
 		<legend>Enter Your Information</legend>
 		

--- a/settings.js
+++ b/settings.js
@@ -1,8 +1,8 @@
 // Change the url to the domain of your app
-exports.url = 'https://gulfex.herokuapp.com';
+exports.url = '';
 
-exports.senderEmail = 'yura@gulfex.net';
-exports.senderName = 'Gulfex';
+exports.senderEmail = '';
+exports.senderName = '';
 
 // set 'exports.listId = null' to add contact to all contacts, but no specific list
 // or a string with the listId to add to a specific list
@@ -10,8 +10,8 @@ exports.listId = 2480976;
 
 // set 'exports.templateId = null' to opt out of using a template
 // or a string with the templateId to use a template
-exports.templateId = 'e439b612-53e0-40f1-8cbf-1ab31649623e';
+exports.templateId = '';
 
 // receive an email when a new signup is confirmed
 exports.sendNotification = true;
-exports.notificationEmail = 'yura@gulfex.net';
+exports.notificationEmail = '';

--- a/settings.js
+++ b/settings.js
@@ -1,8 +1,8 @@
 // Change the url to the domain of your app
 exports.url = 'https://gulfex.herokuapp.com';
 
-exports.senderEmail = "yura@gulfex.net";
-exports.senderName = "Gulfex";
+exports.senderEmail = 'yura@gulfex.net';
+exports.senderName = 'Gulfex';
 
 // set 'exports.listId = null' to add contact to all contacts, but no specific list
 // or a string with the listId to add to a specific list
@@ -10,8 +10,8 @@ exports.listId = 2480976;
 
 // set 'exports.templateId = null' to opt out of using a template
 // or a string with the templateId to use a template
-exports.templateId = e439b612-53e0-40f1-8cbf-1ab31649623e;
+exports.templateId = 'e439b612-53e0-40f1-8cbf-1ab31649623e';
 
 // receive an email when a new signup is confirmed
 exports.sendNotification = true;
-exports.notificationEmail = "yura@gulfex.net";
+exports.notificationEmail = 'yura@gulfex.net';

--- a/settings.js
+++ b/settings.js
@@ -1,17 +1,17 @@
 // Change the url to the domain of your app
-exports.url = 'http://localhost:3090';
+exports.url = 'https://gulfex.herokuapp.com';
 
-exports.senderEmail = "sender@example.com";
-exports.senderName = "Sender Name";
+exports.senderEmail = "yura@gulfex.net";
+exports.senderName = "Gulfex";
 
 // set 'exports.listId = null' to add contact to all contacts, but no specific list
 // or a string with the listId to add to a specific list
-exports.listId = null;
+exports.listId = 2480976;
 
 // set 'exports.templateId = null' to opt out of using a template
 // or a string with the templateId to use a template
-exports.templateId = null;
+exports.templateId = e439b612-53e0-40f1-8cbf-1ab31649623e;
 
 // receive an email when a new signup is confirmed
 exports.sendNotification = true;
-exports.notificationEmail = "admin@example.com";
+exports.notificationEmail = "yura@gulfex.net";

--- a/settings.js
+++ b/settings.js
@@ -1,16 +1,16 @@
 // Change the url to the domain of your app
-exports.url = '';
+exports.url = 'http://localhost:3090';
 
-exports.senderEmail = '';
-exports.senderName = '';
+exports.senderEmail = 'sender@example.com';
+exports.senderName = 'Sender Name';
 
 // set 'exports.listId = null' to add contact to all contacts, but no specific list
 // or a string with the listId to add to a specific list
-exports.listId = 2480976;
+exports.listId = null;
 
 // set 'exports.templateId = null' to opt out of using a template
 // or a string with the templateId to use a template
-exports.templateId = '';
+exports.templateId = null;
 
 // receive an email when a new signup is confirmed
 exports.sendNotification = true;


### PR DESCRIPTION
Quotes the string causing the following error in heroku
```
2018-07-21T12:08:41.796202+00:00 app[web.1]: /app/settings.js:13
2018-07-21T12:08:41.796249+00:00 app[web.1]: exports.templateId = e439b612-53e0-40f1-8cbf-1ab31649623e;
2018-07-21T12:08:41.796251+00:00 app[web.1]: ^^
2018-07-21T12:08:41.796252+00:00 app[web.1]:
2018-07-21T12:08:41.796253+00:00 app[web.1]: SyntaxError: Unexpected identifier
2018-07-21T12:08:41.796254+00:00 app[web.1]: at exports.runInThisContext (vm.js:53:16)
2018-07-21T12:08:41.796256+00:00 app[web.1]: at Module._compile (module.js:413:25)
2018-07-21T12:08:41.796257+00:00 app[web.1]: at Object.Module._extensions..js (module.js:452:10)
2018-07-21T12:08:41.796258+00:00 app[web.1]: at Module.load (module.js:355:32)
2018-07-21T12:08:41.796260+00:00 app[web.1]: at Function.Module._load (module.js:310:12)
2018-07-21T12:08:41.796261+00:00 app[web.1]: at Module.require (module.js:365:17)
2018-07-21T12:08:41.796262+00:00 app[web.1]: at require (module.js:384:17)
2018-07-21T12:08:41.796263+00:00 app[web.1]: at Object.<anonymous> (/app/server/controllers/contact_list_controller.js:5:18)
2018-07-21T12:08:41.796265+00:00 app[web.1]: at Module._compile (module.js:434:26)
2018-07-21T12:08:41.796266+00:00 app[web.1]: at Object.Module._extensions..js (module.js:452:10)
```